### PR TITLE
Frontmatter option to ignore pages in sitemap

### DIFF
--- a/features/template.feature
+++ b/features/template.feature
@@ -23,4 +23,9 @@ Feature: Default template
   Scenario: Page with relevant sitemap front matter should show up in sitemap
     Given a successfully built app at "sitemap-frontmatter-app"
     When I cd to "build"
-    Then the file "sitemap.xml" should contain "<priority>" 
+    Then the file "sitemap.xml" should contain "<priority>"
+
+  Scenario: Page with ignore frontmatter variable should not show up in sitemap
+    Given a successfully built app at "sitemap-frontmatter-app"
+    When I cd to "build"
+    Then the file "sitemap.xml" should not contain "<loc>http://www.example.com/private.html</loc>"

--- a/fixtures/sitemap-frontmatter-app/source/private.html
+++ b/fixtures/sitemap-frontmatter-app/source/private.html
@@ -1,0 +1,4 @@
+---
+ignore: true
+---
+Private page

--- a/lib/middleman-sitemap/extension.rb
+++ b/lib/middleman-sitemap/extension.rb
@@ -20,7 +20,7 @@ class Sitemap < ::Middleman::Extension
   end
 
   def generate_sitemap
-    pages = app.sitemap.resources.find_all{ |p| p.ext == ".html" }
+    pages = get_pages
 
     if pages.count > 50000
       sitemaps = build_multiple_sitemaps(pages)
@@ -93,6 +93,12 @@ class Sitemap < ::Middleman::Extension
   def encode(path)
     str = path.split("/").map { |f| app.escape_html(f) }.join("/")
     return str
+  end
+
+  private
+
+  def get_pages
+    app.sitemap.resources.find_all { |p| p.ext == ".html" && !p.data.ignore }
   end
 
 end


### PR DESCRIPTION
What would you think about this as an option for ignoring pages in the sitemap? Simply add ignore: true to the page's frontmatter:

```
---
ignore: true
---
```