### PR TITLE
Add Compability and Fixes for Middleman 4 & 5

### DIFF
--- a/lib/middleman-sitemap/extension.rb
+++ b/lib/middleman-sitemap/extension.rb
@@ -3,6 +3,8 @@ class Sitemap < ::Middleman::Extension
   option :gzip, true, 'Whether or not to GZIP the resulting file'
   option :hostname, "http://www.example.com", "The hostname for your website"
 
+  include Padrino::Helpers
+
   def initialize(app, options_hash={}, &block)
     # Call super to build options from the options_hash
     super
@@ -91,7 +93,7 @@ class Sitemap < ::Middleman::Extension
 
   # Returns a URL with proper HTML entities
   def encode(path)
-    str = path.split("/").map { |f| app.escape_html(f) }.join("/")
+    str = path.split("/").map { |f| h(f) }.join('/')
     return str
   end
 

--- a/lib/middleman-sitemap/extension.rb
+++ b/lib/middleman-sitemap/extension.rb
@@ -100,7 +100,7 @@ class Sitemap < ::Middleman::Extension
   private
 
   def get_pages
-    app.sitemap.resources.find_all { |p| p.ext == ".html" && !p.data.ignore }
+    app.sitemap.resources.to_a.find_all { |p| p.ext == ".html" && !p.data.ignore }
   end
 
 end

--- a/lib/middleman-sitemap/extension.rb
+++ b/lib/middleman-sitemap/extension.rb
@@ -33,7 +33,7 @@ class Sitemap < ::Middleman::Extension
     if options.gzip
       sitemaps.each do |sitemap|
         gzip_file(sitemap)
-        @builder.say_status :create, "#{sitemap}.gz" if @builder
+        @builder.thor.say_status :create, "#{sitemap}.gz" if @builder
       end
     end
   end
@@ -45,12 +45,12 @@ class Sitemap < ::Middleman::Extension
     template = Tilt::ERBTemplate.new(File.expand_path(File.join("#{File.dirname(__FILE__)}", "../../templates/sitemapindex.xml.erb")))
     sitemap = template.render(self)
 
-    outfile = File.join(app.build_dir, "sitemap.xml")
+    outfile = File.join(app.config.build_dir, "sitemap.xml")
     File.open(outfile, 'w') {|f| f.write(sitemap) }
 
-    @builder.say_status :create, "#{app.build_dir}/sitemap.xml"
+    @builder.thor.say_status :create, "#{app.config.build_dir}/sitemap.xml"
 
-    return "#{app.build_dir}/sitemap.xml"
+    return "#{app.config.build_dir}/sitemap.xml"
   end
 
   def build_sitemap(name, pages)
@@ -60,12 +60,12 @@ class Sitemap < ::Middleman::Extension
     template = Tilt::ERBTemplate.new(templates_path, 0, :trim => '>')
     sitemap = template.render(self)
 
-    outfile = File.join(app.build_dir, name)
+    outfile = File.join(app.config.build_dir, name)
     File.open(outfile, 'w') {|f| f.write(sitemap) }
 
-    @builder.say_status :create, "#{app.build_dir}/#{name}"
+    @builder.thor.say_status :create, "#{app.config.build_dir}/#{name}"
 
-    return "#{app.build_dir}/#{name}"
+    return "#{app.config.build_dir}/#{name}"
   end
 
   def build_multiple_sitemaps(pages)


### PR DESCRIPTION
- Middleman 4+ support
- Fix undefined method `app.escape_html' in Middleman v4.1+, solves #8 
- Fix undefined method `find_all` for `Middleman::Sitemap::ResourceListContainer` in Middleman v5.0.0.rc2+